### PR TITLE
chore: add dot-env for easy db config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+
+# env file
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # keybored-proto
+
+## 1.Setup
+
+1. Install all packages
+    - run `npm i` in keybored-folder t
+2. Create .env file and fill with contents
+
+    ```
+    POSTGRES_USERNAME=<your_postgres_username>
+    POSTGRES_PASSWORD=<your_postgres_pw>
+    POSTGRES_HOST=<your_postgres_host>
+    POSTGRES_DATABASE=keybored_development
+    ```
+
+3. Setup database locally
+    - Create db with `npx sequelize db:create`
+    - Run db migrations with `npx sequelize db:migrate`
+    - Optional: to undo db migrations run `npx sequelize db:migrate:undo`

--- a/config/config.js
+++ b/config/config.js
@@ -1,20 +1,25 @@
+require("dotenv").config();
+
 module.exports = {
   development: {
-    username: 'root',
-    password: null,
-    database: 'keybored_development',
-    host: '127.0.0.1',
-    dialect: 'postgres',
+    username: process.env.POSTGRES_USERNAME,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DATABASE,
+    host: process.env.POSTGRES_HOST,
+    dialect: "postgres",
+  },
+  staging: {
+    username: process.env.POSTGRES_USERNAME,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DATABASE,
+    host: process.env.POSTGRES_HOST,
+    dialect: "postgres",
   },
   production: {
-    use_env_variable: 'DATABASE_URL',
-    dialect: 'postgres',
-    protocol: 'postgres',
-    dialectOptions: {
-      ssl: { // https://github.com/sequelize/sequelize/issues/12083
-        require: true,
-        rejectUnauthorized: false,
-      },
-    },
+    username: process.env.POSTGRES_USERNAME,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DATABASE,
+    host: process.env.POSTGRES_HOST,
+    dialect: "postgres",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cookie-parser": "^1.4.5",
+        "dotenv": "^16.0.1",
         "ejs": "^3.1.5",
         "express": "^4.17.1",
         "method-override": "^3.0.0",
@@ -3602,6 +3603,14 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dottie": {
@@ -14482,6 +14491,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "dottie": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "cookie-parser": "^1.4.5",
+    "dotenv": "^16.0.1",
     "ejs": "^3.1.5",
     "express": "^4.17.1",
     "method-override": "^3.0.0",


### PR DESCRIPTION
### Changes
- added dot env package
- update readme with setup instructions

### How to Test
1. create .env file in keybored-proto folder
2. populate .env with your db creds
@thereseLYR can you try with these? and run the sequelize commands to check if they work
```
POSTGRES_USERNAME=root
POSTGRES_PASSWORD=null
POSTGRES_HOST=127.0.0.1
POSTGRES_DATABASE=keybored_development
```

### Screenshots (if any) 