### PR TITLE
fix: persistent sound on keypress

### DIFF
--- a/src/components/keyboard/Keyboard.jsx
+++ b/src/components/keyboard/Keyboard.jsx
@@ -71,7 +71,7 @@ export default function Keeb() {
   };
 
   const onChangeTitle = (textInputEvent) => {
-    if (titleBoxActive === true) {
+    if (titleBoxActive) {
       setSongTitle(textInputEvent.target.value);
     }
   };


### PR DESCRIPTION
## Changes

- introduced a new state hook to check if keyboard component is in focus or not before updating `input` and playing sound
- above bug had also caused title input to edit songData values. this is also fixed with the focus check.

## How to test

- log in as a guest and create song data
- click into the title box at the bottom of the page, edit the title and ensure that song data in the topmost input box does not change
- return to landing page, and attempt to sign in as a registered user. ensure that the keypresses on 'enabled' buttons do not trigger any sound playback.

## Screenshots (if any)

- N/A
